### PR TITLE
Set FORCE_COLOR to correct values

### DIFF
--- a/src/cmd-process.ts
+++ b/src/cmd-process.ts
@@ -127,7 +127,7 @@ export class CmdProcess {
       cwd:
         this.opts.path ||
         ((process.versions.node < '8.0.0' ? process.cwd : process.cwd()) as string),
-      env: Object.assign(process.env, { FORCE_COLOR: process.stdout.isTTY }),
+      env: Object.assign(process.env, { FORCE_COLOR: process.stdout.isTTY ? '1' : '0' }),
       stdio:
         this.opts.collectLogs || this.opts.prefixer != null || this.opts.doneCriteria
           ? 'pipe'


### PR DESCRIPTION
Currently the `FORCE_COLOR` environment variable is set to one of the string values `"true"` or `"undefined"`. Both of these are interpreted as truthy values.