### PR TITLE
Not setting FORCE_COLOR=0, supporting chalk 1

### DIFF
--- a/src/cmd-process.ts
+++ b/src/cmd-process.ts
@@ -127,7 +127,7 @@ export class CmdProcess {
       cwd:
         this.opts.path ||
         ((process.versions.node < '8.0.0' ? process.cwd : process.cwd()) as string),
-      env: Object.assign(process.env, { FORCE_COLOR: process.stdout.isTTY ? '1' : '0' }),
+      env: Object.assign(process.env, process.stdout.isTTY ? { FORCE_COLOR: '1' } : {}),
       stdio:
         this.opts.collectLogs || this.opts.prefixer != null || this.opts.doneCriteria
           ? 'pipe'


### PR DESCRIPTION
`chalk` v2 supports a `FORCE_COLOR` environment variable having values `0` or `1` to explicitly disable or enable colors.

https://github.com/chalk/chalk/tree/v2.4.2#chalksupportscolor

`chalk` v1 treats any value as force enable.

https://github.com/chalk/chalk/tree/v1.1.3#chalksupportscolor

This change will make `wsrun` support both versions of `chalk`.