### PR TITLE
Gracefully handle misconfigured packages with no name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,14 @@ const packageJsonWorkspacesNohoistFormat = packageJsonWorkspaces && packageJsonW
 
 const workspaceGlobs = packageJsonWorkspacesNohoistFormat || packageJsonWorkspaces || ['packages/*']
 
-const pkgs = listPkgs('./', workspaceGlobs)
+let pkgs
+try {
+  pkgs = listPkgs('./', workspaceGlobs)
+} catch (err) {
+  console.error(chalk.red(`\nERROR: ${err.message}`))
+  process.exit(1)
+}
+
 const pkgPaths = _.mapValues(_.keyBy(pkgs, p => p.json.name), v => v.path)
 
 const pkgJsons = _.map(pkgs, pkg => pkg.json)

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -38,6 +38,7 @@ export function listPkgs(wsRoot: string, globs: string[]) {
         return
       }
       const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
+      if (!pkgJson.name) throw new Error(`Package in directory ${f} has no name in package.json`)
       packages[pkgJson.name] = {
         path: path.join(wsRoot, f),
         json: pkgJson

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -184,4 +184,19 @@ describe('basic', () => {
       }
     )
   })
+
+  it('should show an error for pkgs without name', async () => {
+    await withScaffold(
+      {
+        packages: [
+          echo.makePkg({ path: 'packages/p1', dependencies: {} }),
+        ]
+      },
+      async () => {
+        let tst = await wsrun('doecho')
+        expect(tst.status).toBeTruthy()
+        expect(String(tst.output[2])).toEqual('\nERROR: Package in directory packages/p1 has no name in package.json\n')
+      }
+    )
+  })
 })

--- a/tests/test.util.ts
+++ b/tests/test.util.ts
@@ -20,7 +20,7 @@ let rimrafAsync = promisify(rimraf)
 let mkdirpAsync = promisify(mkdirp)
 
 export type PackageJson = {
-  name: string
+  name?: string
   path?: string
   dependencies?: { [name: string]: string }
   devDependencies?: { [name: string]: string }


### PR DESCRIPTION
Great project. Ran into a not so friendly error message when I had a misconfigured package with no `name` field. Tracked it down, but figured it'd be nice if there wasn't an exposed error from `minimatch` if this happened.