### PR TITLE
fix(rewriting):actually disable path rewriting by default

### DIFF
--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -21,7 +21,7 @@ class Prefixer {
   prefixer = (basePath: string, pkg: string, line: string) => {
     let l = ''
     if (this.currentName != pkg) l += chalk.bold((this.currentName = pkg)) + '\n'
-    l += ' | ' + this.processFilePaths(basePath, line)
+    l += ' | ' + line // this.processFilePaths(basePath, line)
     return l
   }
 
@@ -64,7 +64,6 @@ export class RunGraph {
     public opts: GraphOptions,
     public pkgPaths: Dict<string>
   ) {
-
     this.checkResultsAndReport = this.checkResultsAndReport.bind(this)
     this.closeAll = this.closeAll.bind(this)
 

--- a/tests/__snapshots__/basic.ts.snap
+++ b/tests/__snapshots__/basic.ts.snap
@@ -4,7 +4,7 @@ exports[`basic should keep its stdout and stderr stable 1`] = `
 "@x/p1
  | $ sleep $1; echo @x/p1 $1 >> '/tmp/wsrun-test-1/echo.out' 0 Hello
 @x/p2
- | $ sleep $1; echo @x/p2 $1 >> '/home/spion/Projects/wsrun/tmp/wsrun-test-1/echo.out' 0 Hello
+ | $ sleep $1; echo @x/p2 $1 >> '/tmp/wsrun-test-1/echo.out' 0 Hello
 "
 `;
 

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -203,6 +203,24 @@ describe('basic', () => {
     )
   })
 
+  it('should not rewrite paths by default', async () => {
+    await withScaffold(
+      {
+        packages: [
+          echo.makePkg(
+            { name: 'app-x-frontend', dependencies: {} },
+            '',
+            'Output for path src/index.ts testing'
+          )
+        ]
+      },
+      async () => {
+        let tst = await wsrun('printthis', {})
+        expect(tst.output.toString()).not.toContain('app-x-frontend/src/index.ts')
+      }
+    )
+  })
+
   it('should show an error for pkgs without name', async () => {
     await withScaffold(
       {

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -237,7 +237,7 @@ describe('basic', () => {
   })
 
   function removePath(processOutput: string) {
-    return processOutput.replace(process.cwd(), '')
+    return processOutput.split(process.cwd()).join('')
   }
   it('should keep its stdout and stderr stable', async () => {
     await withScaffold(


### PR DESCRIPTION
The path rewriting was still happening in the prefixer

TODO: decide whether we want to bump major again. Technically we published 4.0.x without an actual breaking change due to no path rewriting