### PR TITLE
chore: Add config for semantic-pull-requests

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
Add config to check only PR titles. This config is for https://github.com/probot/semantic-pull-requests bot.