### PR TITLE
fix: path rewriting did not work correctly

### DIFF
--- a/src/cmd-process.ts
+++ b/src/cmd-process.ts
@@ -11,7 +11,7 @@ export interface CmdOptions {
   silent?: boolean
   collectLogs: boolean
   prefixer?: (basePath: string, pkg: string, line: string) => string
-  pathRewriter?: (basePath: string, pkg: string, line: string) => string
+  pathRewriter?: (currentPath: string, line: string) => string
   doneCriteria?: string
   path: string
 }
@@ -107,9 +107,7 @@ export class CmdProcess {
   }
 
   private autoPathRewrite(line: string) {
-    return this.opts.pathRewriter
-      ? this.opts.pathRewriter(this.opts.path, this.pkgName, line)
-      : line
+    return this.opts.pathRewriter ? this.opts.pathRewriter(this.opts.path, line) : line
   }
 
   private autoAugmentLine(line: string) {

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -24,10 +24,6 @@ class Prefixer {
     l += ' | ' + line // this.processFilePaths(basePath, line)
     return l
   }
-
-  processFilePaths(basePath: string, line: string) {
-    return fixPaths(this.wspath, basePath, line)
-  }
 }
 
 export interface GraphOptions {
@@ -57,7 +53,7 @@ export class RunGraph {
   private resultMap = new Map<string, Result>()
   private throat: PromiseFnRunner = passThrough
   prefixer = new Prefixer(this.opts.workspacePath).prefixer
-  pathRewriter = fixPaths
+  pathRewriter = (pkgPath: string, line: string) => fixPaths(this.opts.workspacePath, pkgPath, line)
 
   constructor(
     public pkgJsons: PkgJson[],

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -185,20 +185,16 @@ describe('basic', () => {
     )
   })
 
-  it('should not rewrite paths by default', async () => {
+  it('should rewrite paths if instructed', async () => {
     await withScaffold(
       {
         packages: [
-          echo.makePkg(
-            { name: 'app-x-frontend', dependencies: {} },
-            '',
-            'Output for path src/index.ts testing'
-          )
+          echo.makePkg({ name: 'app-x-frontend', dependencies: {} }, '', 'X src/index.ts testing')
         ]
       },
       async () => {
         let tst = await wsrun('printthis', { WSRUN_REWRITE_PATHS: 'true' })
-        expect(tst.output.toString()).toContain('app-x-frontend/src/index.ts')
+        expect(tst.output.toString()).toContain('X packages/app-x-frontend/src/index.ts')
       }
     )
   })


### PR DESCRIPTION
Arguments are not being passed to the CmdProcess, resulting with bogus path rewrites, e.g "src/some-service.ts" for the "app-backend" package would be rewritten as " ../../app-backend/src/some-service.ts"