### PR TITLE
fix: Output order and streaming preservation for collect-logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "rimraf": "^2.6.2",
     "semantic-release": "^15.13.18",
     "ts-jest": "23.10.5",
+    "ts-mockito": "^2.5.0",
     "typescript": "^3.1.1"
   },
   "scripts": {

--- a/src/console.spec.ts
+++ b/src/console.spec.ts
@@ -1,0 +1,88 @@
+import { SerializedConsole } from './console';
+import { mock, instance, verify } from 'ts-mockito';
+
+function nextTick() {
+    return new Promise(resolve => setImmediate(resolve));
+}
+
+describe('serialized console', () => {
+    let console: Console;
+
+    let c: SerializedConsole;
+
+    beforeEach(() => {
+        console = mock();
+        c = new SerializedConsole(instance(console));
+    })
+
+    it('should only output from the active console', () => {
+        let c1 = c.create();
+        let c2 = c.create();
+
+        c1.log('hello 1');
+        verify(console.log('hello 1')).once();
+        c2.log('hello 2');
+        verify(console.log('hello 2')).never();
+        c1.log('hello 3');
+        verify(console.log('hello 3')).once();
+        c2.log('hello 4');
+        verify(console.log('hello 4')).never();
+    })
+
+    it('should output the second console when the first is done', async () => {
+        let c1 = c.create();
+        let c2 = c.create();
+
+        c1.log('hello 1');
+        verify(console.log('hello 1')).once();
+        c2.log('hello 2');
+        verify(console.log('hello 2')).never();
+
+        c.done(c1);
+        await nextTick();
+
+        verify(console.log('hello 2')).once();
+
+        c2.log('hello 3');
+        verify(console.log('hello 3')).once();
+    })
+
+    it('should output from all consoles when they are done in the wrong order', async () => {
+        let c1 = c.create();
+        let c2 = c.create();
+        let c3 = c.create();
+
+        c1.log('hello 1');
+        verify(console.log('hello 1')).once();
+        c2.log('hello 2');
+        verify(console.log('hello 2')).never();
+        c3.log('hello 3');
+        verify(console.log('hello 3')).never();
+
+        c.done(c2)
+        await nextTick();
+
+        verify(console.log('hello 2')).never();
+        verify(console.log('hello 3')).never();
+
+        c.done(c1)
+        await nextTick();
+
+        verify(console.log('hello 2')).once();
+        verify(console.log('hello 3')).once();
+    })
+
+    it('should log from console created after the first one is done', async () => {
+        let c1 = c.create();
+
+        c1.log('hello 1');
+        verify(console.log('hello 1')).once();
+        c.done(c1);
+        await nextTick();
+
+        let c2 = c.create();
+
+        c2.log('hello 2');
+        verify(console.log('hello 2')).once();
+    })
+})

--- a/src/console.ts
+++ b/src/console.ts
@@ -1,0 +1,84 @@
+import { defer } from './utils'
+
+export interface IConsole {
+    log(msg: string): void;
+    error(msg: string): void;
+}
+
+export interface ConsoleFactory {
+    create(): IConsole;
+    done(c: IConsole): void;
+}
+
+class SerializedConsoleImpl implements IConsole {
+    private _activeOutput = false;
+    private _outputBuffer: { type: 'stderr' | 'stdout', line: string }[] = []
+    public finished = defer<void>();
+
+    constructor(private _console: Console) {
+    }
+
+    activeOutput() {
+        this._activeOutput = true;
+
+        this._outputBuffer.forEach(line => {
+            if (line.type === 'stdout') this._console.log(line.line)
+            else this._console.error(line.line)
+        })
+        this._outputBuffer = [];
+    }
+
+    log(msg: string) {
+        if (this._activeOutput) this._console.log(msg)
+        else this._outputBuffer.push({ type: 'stdout', line: msg })
+    }
+
+    error(msg: string) {
+        if (this._activeOutput) this._console.error(msg)
+        else this._outputBuffer.push({ type: 'stderr', line: msg })
+    }
+}
+
+export class SerializedConsole implements ConsoleFactory {
+    private _active: SerializedConsoleImpl | undefined;
+    private _list: SerializedConsoleImpl[] = [];
+
+    constructor(private _console: Console) {
+    }
+
+    private _start(c: SerializedConsoleImpl) {
+        this._active = c;
+        this._active.activeOutput();
+
+        this._active.finished.promise.then(() => {
+            this._active = undefined;
+
+            let next = this._list.shift();
+            if (next) {
+                this._start(next);
+            }
+        })
+    }
+
+    create() {
+        let c = new SerializedConsoleImpl(this._console);
+        if (!this._active) {
+            this._start(c);
+        } else {
+            this._list.push(c);
+        }
+        return c;
+    }
+
+    done(c: IConsole) {
+        (c as SerializedConsoleImpl).finished.resolve();
+    }
+}
+
+export class DefaultConsole implements ConsoleFactory {
+    create() {
+        return console;
+    }
+
+    done(c: IConsole) { }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3889,6 +3889,11 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
   integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
 
+lodash@^4.17.5:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -6518,6 +6523,13 @@ ts-jest@23.10.5:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+ts-mockito@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.5.0.tgz#ad853051f2d116dfcaf6de6b0a1df2c82eda2d1f"
+  integrity sha512-b3qUeMfghRq5k5jw3xNJcnU9RKhqKnRn0k9v9QkN+YpuawrFuMIiGwzFZCpdi5MHy26o7YPnK8gag2awURl3nA==
+  dependencies:
+    lodash "^4.17.5"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
There are two commits in this PR

## Output order

Keep the order between stdout and stderr. It is confusing to have all of stderr at the end of the output, because it loses context. Now the output is in the same order as if there was no buffering of output.

## Collect logs

If you run with `--collect-logs` you have to wait for each package process to be completed before any output is shown.
With this PR, one process at the time is allowed to write straight to console out. This means that you will see the output as it is generated, for one of the parallel processes. The other processes will be buffered as usual.
When the process that writes straight to console out is done, the next process is picked, its log buffer is flushed, and it is allowed to write to console out.

## Result

The result is that the output of running in parallel is much more similar to the output of running serial.