### PR TITLE
Add name-prefix option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ let yargsParser = yargs
       'fast-exit',
       'collect-logs',
       'no-prefix',
+      'name-prefix',
       'rewrite-paths',
       'bin',
       'done-criteria',
@@ -98,6 +99,12 @@ let yargsParser = yargs
     'no-prefix': {
       boolean: true,
       describe: "Don't prefix output"
+    },
+    'name-prefix': {
+      alias: 'n',
+      default: false,
+      boolean: true,
+      describe: "Prefix output with package name"
     },
     'rewrite-paths': {
       boolean: true,
@@ -202,7 +209,8 @@ let runner = new RunGraph(
     bin,
     fastExit,
     collectLogs,
-    addPrefix,
+    addPrefix: addPrefix || argv.namePrefix,
+    linePrefix: argv.namePrefix ? '' : ' | ',
     rewritePaths,
     mode: mode as any,
     recursive,

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -16,12 +16,12 @@ let mkThroat = require('throat')(Bromise) as ((limit: number) => PromiseFnRunner
 let passThrough: PromiseFnRunner = f => f()
 
 class Prefixer {
-  constructor(private wspath: string) {}
+  constructor(private wspath: string, private linePrefix: string) { }
   private currentName = ''
   prefixer = (basePath: string, pkg: string, line: string) => {
     let l = ''
     if (this.currentName != pkg) l += chalk.bold((this.currentName = pkg)) + '\n'
-    l += ' | ' + line // this.processFilePaths(basePath, line)
+    l += this.linePrefix + line // this.processFilePaths(basePath, line)
     return l
   }
 }
@@ -31,6 +31,7 @@ export interface GraphOptions {
   fastExit: boolean
   collectLogs: boolean
   addPrefix: boolean
+  linePrefix: string;
   rewritePaths: boolean
   mode: 'parallel' | 'serial' | 'stages'
   recursive: boolean
@@ -52,7 +53,7 @@ export class RunGraph {
   private runList = new Set<string>()
   private resultMap = new Map<string, Result>()
   private throat: PromiseFnRunner = passThrough
-  prefixer = new Prefixer(this.opts.workspacePath).prefixer
+  prefixer = new Prefixer(this.opts.workspacePath, this.opts.linePrefix).prefixer
   pathRewriter = (pkgPath: string, line: string) => fixPaths(this.opts.workspacePath, pkgPath, line)
 
   constructor(


### PR DESCRIPTION
## Description

This adds an argument, `--name-prefix`, that removes the prefix on each line, and only prints the package name before each package is run.