### PR TITLE
Fix collect logs

### DIFF
--- a/src/cmd-process.ts
+++ b/src/cmd-process.ts
@@ -67,7 +67,7 @@ export class CmdProcess {
   }
 
   constructor(
-    private console: IConsole,
+    public console: IConsole,
     private cmd: string[],
     private pkgName: string,
     private opts: CmdOptions

--- a/src/cmd-process.ts
+++ b/src/cmd-process.ts
@@ -9,7 +9,6 @@ import { defer } from './utils'
 import { IConsole } from './console'
 
 export interface CmdOptions {
-  rejectOnNonZeroExit: boolean
   silent?: boolean
   stdio: 'inherit' | 'pipe'
   pathRewriter?: (currentPath: string, line: string) => string
@@ -75,7 +74,6 @@ export class CmdProcess {
       if (code > 0) {
         const msg = '`' + this.cmdString + '` failed with exit code ' + code
         if (!this.opts.silent) this.console.error(this.autoAugmentLine(msg))
-        if (this.opts.rejectOnNonZeroExit) return this._finished.reject(new Error(msg))
       }
       this._finished.resolve()
     })

--- a/src/console.spec.ts
+++ b/src/console.spec.ts
@@ -85,4 +85,25 @@ describe('serialized console', () => {
     c2.log('hello 2')
     verify(console.log('hello 2')).once()
   })
+
+  it('should not output from discarded console', async () => {
+    let c1 = c.create()
+    c1.log('hello 1')
+    let c2 = c.create()
+    c2.log('hello 2')
+    let c3 = c.create()
+    c3.log('hello 3')
+
+    verify(console.log('hello 1')).once()
+
+    c.discard(c2)
+
+    c.done(c1)
+    await nextTick()
+    verify(console.log('hello 3')).once()
+
+    c.done(c3)
+    await nextTick()
+    verify(console.log('hello 2')).never()
+  })
 })

--- a/src/console.spec.ts
+++ b/src/console.spec.ts
@@ -12,12 +12,12 @@ describe('serialized console', () => {
 
   beforeEach(() => {
     console = mock()
-    c = new SerializedConsole(instance(console))
+    c = new SerializedConsole()
   })
 
   it('should only output from the active console', () => {
-    let c1 = c.create()
-    let c2 = c.create()
+    let c1 = c.create(instance(console))
+    let c2 = c.create(instance(console))
 
     c1.log('hello 1')
     verify(console.log('hello 1')).once()
@@ -30,8 +30,8 @@ describe('serialized console', () => {
   })
 
   it('should output the second console when the first is done', async () => {
-    let c1 = c.create()
-    let c2 = c.create()
+    let c1 = c.create(instance(console))
+    let c2 = c.create(instance(console))
 
     c1.log('hello 1')
     verify(console.log('hello 1')).once()
@@ -48,9 +48,9 @@ describe('serialized console', () => {
   })
 
   it('should output from all consoles when they are done in the wrong order', async () => {
-    let c1 = c.create()
-    let c2 = c.create()
-    let c3 = c.create()
+    let c1 = c.create(instance(console))
+    let c2 = c.create(instance(console))
+    let c3 = c.create(instance(console))
 
     c1.log('hello 1')
     verify(console.log('hello 1')).once()
@@ -73,25 +73,25 @@ describe('serialized console', () => {
   })
 
   it('should log from console created after the first one is done', async () => {
-    let c1 = c.create()
+    let c1 = c.create(instance(console))
 
     c1.log('hello 1')
     verify(console.log('hello 1')).once()
     c.done(c1)
     await nextTick()
 
-    let c2 = c.create()
+    let c2 = c.create(instance(console))
 
     c2.log('hello 2')
     verify(console.log('hello 2')).once()
   })
 
   it('should not output from discarded console', async () => {
-    let c1 = c.create()
+    let c1 = c.create(instance(console))
     c1.log('hello 1')
-    let c2 = c.create()
+    let c2 = c.create(instance(console))
     c2.log('hello 2')
-    let c3 = c.create()
+    let c3 = c.create(instance(console))
     c3.log('hello 3')
 
     verify(console.log('hello 1')).once()

--- a/src/console.ts
+++ b/src/console.ts
@@ -8,7 +8,6 @@ export interface IConsole {
 
 export interface ConsoleFactory {
   create(console: IConsole): IConsole
-  active(c: IConsole): boolean
   discard(c: IConsole): void
   done(c: IConsole): void
   flush(): Bromise<void>
@@ -71,10 +70,6 @@ export class SerializedConsole implements ConsoleFactory {
       this._list.push(c)
     }
     return c
-  }
-
-  active(c: IConsole) {
-    return c === this._active
   }
 
   discard(c: IConsole) {

--- a/src/console.ts
+++ b/src/console.ts
@@ -7,6 +7,8 @@ export interface IConsole {
 
 export interface ConsoleFactory {
   create(): IConsole
+  active(c: IConsole): boolean
+  discard(c: IConsole): void
   done(c: IConsole): void
 }
 
@@ -68,6 +70,14 @@ export class SerializedConsole implements ConsoleFactory {
     return c
   }
 
+  active(c: IConsole) {
+    return c === this._active
+  }
+
+  discard(c: IConsole) {
+    this._list = this._list.filter(_c => c !== _c)
+  }
+
   done(c: IConsole) {
     ;(c as SerializedConsoleImpl).finished.resolve()
   }
@@ -78,5 +88,10 @@ export class DefaultConsole implements ConsoleFactory {
     return console
   }
 
+  active(c: IConsole) {
+    return true
+  }
+
+  discard(c: IConsole) {}
   done(c: IConsole) {}
 }

--- a/src/console.ts
+++ b/src/console.ts
@@ -6,7 +6,7 @@ export interface IConsole {
 }
 
 export interface ConsoleFactory {
-  create(): IConsole
+  create(console: IConsole): IConsole
   active(c: IConsole): boolean
   discard(c: IConsole): void
   done(c: IConsole): void
@@ -44,8 +44,6 @@ export class SerializedConsole implements ConsoleFactory {
   private _active: SerializedConsoleImpl | undefined
   private _list: SerializedConsoleImpl[] = []
 
-  constructor(private _console: Console) {}
-
   private _start(c: SerializedConsoleImpl) {
     this._active = c
     this._active.activeOutput()
@@ -60,8 +58,8 @@ export class SerializedConsole implements ConsoleFactory {
     })
   }
 
-  create() {
-    let c = new SerializedConsoleImpl(this._console)
+  create(parent: IConsole) {
+    let c = new SerializedConsoleImpl(parent)
     if (!this._active) {
       this._start(c)
     } else {
@@ -84,8 +82,8 @@ export class SerializedConsole implements ConsoleFactory {
 }
 
 export class DefaultConsole implements ConsoleFactory {
-  create() {
-    return console
+  create(parent: IConsole) {
+    return parent
   }
 
   active(c: IConsole) {
@@ -94,4 +92,28 @@ export class DefaultConsole implements ConsoleFactory {
 
   discard(c: IConsole) {}
   done(c: IConsole) {}
+}
+
+export class PrefixedConsole implements IConsole {
+  private static _last: PrefixedConsole | undefined
+
+  constructor(private _console: IConsole, private _name: string, private _prefix: string) {}
+
+  log(msg: string) {
+    if (PrefixedConsole._last !== this) {
+      this._console.log(this._name + '\n' + this._prefix + msg)
+      PrefixedConsole._last = this
+    } else {
+      this._console.log(this._prefix + msg)
+    }
+  }
+
+  error(msg: string) {
+    if (PrefixedConsole._last !== this) {
+      this._console.error(this._name + '\n' + this._prefix + msg)
+      PrefixedConsole._last = this
+    } else {
+      this._console.error(this._prefix + msg)
+    }
+  }
 }

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -84,7 +84,7 @@ export class RunGraph {
     if (this.opts.fastExit) {
       if (this.opts.collectLogs) {
         this.children.forEach(c => {
-          if (c !== child && !this.consoles.active(c.console)) {
+          if (c !== child) {
             this.consoles.discard(c.console)
             c.stop()
           }

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -371,6 +371,7 @@ export class RunGraph {
       Bromise.all(pkgs.map(pkg => this.lookupOrRun(cmd, pkg)))
         // Wait for any of them to error
         .then(() => Bromise.all(this.children.map(c => c.result)))
+        .then(() => this.consoles.flush())
         // Generate report
         .then(() => this.checkResultsAndReport(cmd, pkgs))
     )

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -7,7 +7,13 @@ import { uniq, intersection } from 'lodash'
 import { CmdProcess } from './cmd-process'
 import minimatch = require('minimatch')
 import { fixPaths } from './fix-paths'
-import { ConsoleFactory, SerializedConsole, DefaultConsole, IConsole } from './console'
+import {
+  ConsoleFactory,
+  SerializedConsole,
+  DefaultConsole,
+  IConsole,
+  PrefixedConsole
+} from './console'
 import { getChangedFilesForRoots } from 'jest-changed-files'
 import { filterChangedPackages } from './filter-changed-packages'
 import { expandRevDeps } from './rev-deps'
@@ -18,17 +24,6 @@ type PromiseFnRunner = <T>(f: PromiseFn<T>) => Bromise<T>
 let mkThroat = require('throat')(Bromise) as (limit: number) => PromiseFnRunner
 
 let passThrough: PromiseFnRunner = f => f()
-
-class Prefixer {
-  constructor() {}
-  private currentName = ''
-  prefixer = (basePath: string, pkg: string, line: string) => {
-    let l = ''
-    if (this.currentName != pkg) l += chalk.bold((this.currentName = pkg)) + '\n'
-    l += ' | ' + line // this.processFilePaths(basePath, line)
-    return l
-  }
-}
 
 export interface GraphOptions {
   bin: string
@@ -59,7 +54,6 @@ export class RunGraph {
   private resultMap = new Map<string, Result>()
   private throat: PromiseFnRunner = passThrough
   private consoles: ConsoleFactory
-  private prefixer = new Prefixer().prefixer
   pathRewriter = (pkgPath: string, line: string) => fixPaths(this.opts.workspacePath, pkgPath, line)
 
   constructor(
@@ -77,7 +71,7 @@ export class RunGraph {
     else if (this.opts.mode === 'stages') this.throat = mkThroat(opts.concurrency || 16)
     else if (opts.concurrency) this.throat = mkThroat(opts.concurrency)
 
-    if (opts.collectLogs) this.consoles = new SerializedConsole(console)
+    if (opts.collectLogs) this.consoles = new SerializedConsole()
     else this.consoles = new DefaultConsole()
   }
 
@@ -146,12 +140,13 @@ export class RunGraph {
 
   private runCondition(cmd: string, pkg: string) {
     let cmdLine = this.makeCmd(cmd.split(' '))
-    let c = this.consoles.create()
-    const child = new CmdProcess(c, cmdLine, pkg, {
+    let c = this.consoles.create(
+      this.opts.addPrefix ? new PrefixedConsole(console, chalk.bold(pkg), ' | ') : console
+    )
+    const child = new CmdProcess(c, cmdLine, {
       rejectOnNonZeroExit: false,
       silent: true,
-      collectLogs: this.opts.collectLogs,
-      prefixer: this.opts.addPrefix ? this.prefixer : undefined,
+      stdio: this.opts.collectLogs || this.opts.addPrefix ? 'pipe' : 'inherit',
       doneCriteria: this.opts.doneCriteria,
       path: this.pkgPaths[pkg]
     })
@@ -199,11 +194,12 @@ export class RunGraph {
         }
 
         let cmdLine = this.makeCmd(cmdArray)
-        let c = this.consoles.create()
-        const child = new CmdProcess(c, cmdLine, pkg, {
+        let c = this.consoles.create(
+          this.opts.addPrefix ? new PrefixedConsole(console, chalk.bold(pkg), ' | ') : console
+        )
+        const child = new CmdProcess(c, cmdLine, {
           rejectOnNonZeroExit: this.opts.fastExit,
-          collectLogs: this.opts.collectLogs,
-          prefixer: this.opts.addPrefix ? this.prefixer : undefined,
+          stdio: this.opts.collectLogs || this.opts.addPrefix ? 'pipe' : 'inherit',
           pathRewriter: this.opts.rewritePaths ? this.pathRewriter : undefined,
           doneCriteria: this.opts.doneCriteria,
           path: this.pkgPaths[pkg]
@@ -374,8 +370,6 @@ export class RunGraph {
     return (
       Bromise.all(pkgs.map(pkg => this.lookupOrRun(cmd, pkg)))
         // Wait for any of them to error
-        .then(() => Bromise.all(this.children.map(c => c.exitCode)))
-        // Wait for the all the processes to finish
         .then(() => Bromise.all(this.children.map(c => c.result)))
         // Generate report
         .then(() => this.checkResultsAndReport(cmd, pkgs))

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -80,13 +80,19 @@ export class RunGraph {
     this.children.forEach(ch => ch.stop())
   }
 
-  private handleFailedChild(child: CmdProcess, console: IConsole) {
-    this.children.forEach(c => {
-      if (c !== child && !this.consoles.active(c.console)) {
-        this.consoles.discard(c.console)
-        c.stop()
+  private handleFailedChild(child: CmdProcess) {
+    if (this.opts.fastExit) {
+      if (this.opts.collectLogs) {
+        this.children.forEach(c => {
+          if (c !== child && !this.consoles.active(c.console)) {
+            this.consoles.discard(c.console)
+            c.stop()
+          }
+        })
+      } else {
+        this.closeAll()
       }
-    })
+    }
   }
 
   private lookupOrRun(cmd: string[], pkg: string): Bromise<ProcResolution> {
@@ -144,7 +150,6 @@ export class RunGraph {
       this.opts.addPrefix ? new PrefixedConsole(console, chalk.bold(pkg), ' | ') : console
     )
     const child = new CmdProcess(c, cmdLine, {
-      rejectOnNonZeroExit: false,
       silent: true,
       stdio: this.opts.collectLogs || this.opts.addPrefix ? 'pipe' : 'inherit',
       doneCriteria: this.opts.doneCriteria,
@@ -156,13 +161,31 @@ export class RunGraph {
     return rres
   }
 
+  private isFailed(pkg: string) {
+    let res = this.resultMap.get(pkg)
+    if (typeof res === 'number' && res !== 0) {
+      return true
+    } else if (res === ResultSpecialValues.Cancelled) {
+      return true
+    } else {
+      return false
+    }
+  }
+
   private runOne(cmdArray: string[], pkg: string): Bromise<ProcResolution> {
     let p = this.jsonMap.get(pkg)
     if (p == null) throw new Error('Unknown package: ' + pkg)
-    let myDeps = Bromise.all(this.allDeps(p).map(d => this.lookupOrRun(cmdArray, d)))
+    let deps = this.allDeps(p)
+    let myDeps = Bromise.all(deps.map(d => this.lookupOrRun(cmdArray, d)))
 
     return myDeps.then(depsStatuses => {
       this.resultMap.set(pkg, ResultSpecialValues.Pending)
+
+      if (deps.some(d => this.isFailed(d))) {
+        // Don't run if any dependency failed
+        this.resultMap.set(pkg, ResultSpecialValues.Cancelled)
+        return Bromise.resolve(ProcResolution.Normal)
+      }
 
       if (this.opts.exclude.indexOf(pkg) >= 0) {
         console.log(chalk.bold(pkg), 'in exclude list, skipping')
@@ -198,7 +221,6 @@ export class RunGraph {
           this.opts.addPrefix ? new PrefixedConsole(console, chalk.bold(pkg), ' | ') : console
         )
         const child = new CmdProcess(c, cmdLine, {
-          rejectOnNonZeroExit: this.opts.fastExit,
           stdio: this.opts.collectLogs || this.opts.addPrefix ? 'pipe' : 'inherit',
           pathRewriter: this.opts.rewritePaths ? this.pathRewriter : undefined,
           doneCriteria: this.opts.doneCriteria,
@@ -206,9 +228,7 @@ export class RunGraph {
         })
         child.exitCode.then(() => this.consoles.done(c))
         child.exitCode.then(code => this.resultMap.set(pkg, code))
-        child.exitCode.then(
-          code => code > 0 && this.opts.fastExit && this.handleFailedChild(child, c)
-        )
+        child.exitCode.then(code => code > 0 && this.handleFailedChild(child))
         this.children.push(child)
         return Promise.resolve({ status: ProcResolution.Normal, process: child })
       })

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -1,5 +1,5 @@
 import 'jest'
-import { withScaffold, echo, wsrun } from './test.util'
+import { withScaffold, echo, wsrun, makePkg } from './test.util'
 
 let pkgList = (errorp3: boolean = false, condition?: string) => [
   echo.makePkg({ name: 'p1', dependencies: { p2: '*' } }, condition),
@@ -249,5 +249,82 @@ describe('basic', () => {
         expect(removePath(tst.stderr.toString())).toMatchSnapshot()
       }
     )
+  })
+
+  function getTestOutput(stdout: Buffer) {
+    return stdout
+      .toString()
+      .split('\n')
+      .filter(line => line.match(/^ \| test -> /))
+      .map(line => /^ \| test -> (.*)$/.exec(line)![1])
+  }
+
+  describe('collect-logs', () => {
+    it('should fail with error if background process fails', async () => {
+      await withScaffold(
+        {
+          packages: [
+            makePkg('p1', {}, 'echo "test -> p1.1" ; sleep 1 ; echo "test -> p1.2"'),
+            makePkg('p2', {}, 'echo "test -> p2.1" ; exit 1')
+          ]
+        },
+        async () => {
+          let tst = await wsrun('--parallel --collect-logs dorun')
+          expect(tst.status).toBe(1)
+        }
+      )
+    })
+
+    it('should print the output from a failed background process after the output from the foreground process', async () => {
+      await withScaffold(
+        {
+          packages: [
+            makePkg('p1', {}, "echo 'test -> p1.1' ; sleep 1 ; echo 'test -> p1.2'"),
+            makePkg('p2', {}, "echo 'test -> p2.1' ; exit 1")
+          ]
+        },
+        async () => {
+          let tst = await wsrun('--parallel --collect-logs dorun')
+          expect(tst.status).toBe(1)
+          expect(getTestOutput(tst.stdout)).toEqual(['p1.1', 'p1.2', 'p2.1'])
+        }
+      )
+    })
+  })
+
+  describe('terminating', () => {
+    it('should not run dependent packages if one fails using --stages', async () => {
+      await withScaffold(
+        {
+          packages: [
+            makePkg('p1', { p2: '*' }, "echo 'test -> p1.1'"),
+            makePkg('p2', { p3: '*' }, "echo 'test -> p2.1'"),
+            makePkg('p3', {}, "echo 'test -> p3.1' ; exit 1")
+          ]
+        },
+        async () => {
+          let tst = await wsrun('--stages dorun')
+          expect(tst.status).toBe(1)
+          expect(getTestOutput(tst.stdout)).toEqual(['p3.1'])
+        }
+      )
+    })
+
+    it('should not run dependent packages if one fails using --stages and --collect-logs', async () => {
+      await withScaffold(
+        {
+          packages: [
+            makePkg('p1', { p2: '*' }, "echo 'test -> p1.1'"),
+            makePkg('p2', { p3: '*' }, "echo 'test -> p2.1'"),
+            makePkg('p3', {}, "echo 'test -> p3.1' ; exit 1")
+          ]
+        },
+        async () => {
+          let tst = await wsrun('--stages --collect-logs dorun')
+          expect(tst.status).toBe(1)
+          expect(getTestOutput(tst.stdout)).toEqual(['p3.1'])
+        }
+      )
+    })
   })
 })

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -11,4 +11,4 @@ fi
 
 BASHCMD="$RUNCMD ${@:2}"
 echo '$' $BASHCMD
-exec bash -c "$BASHCMD"
+exec bash -c "trap 'kill \$\$' SIGINT ; $BASHCMD"

--- a/tests/test.util.ts
+++ b/tests/test.util.ts
@@ -100,6 +100,18 @@ export let echo = {
   }
 }
 
+export function makePkg(name: string, dependencies: { [name: string]: string }, script: string) {
+  return {
+    name,
+    path: `packages/${name}`,
+    dependencies,
+    license: 'MIT',
+    scripts: {
+      dorun: script
+    }
+  }
+}
+
 let pkgPath = path.resolve(__dirname, '..')
 let binPath = require('../package.json').bin.wsrun
 let wsrunPath = path.resolve(pkgPath, binPath)


### PR DESCRIPTION
There is a problem in how `--collect-logs` works, when jobs fail.

### Problem

`wsrun --parallell --fast-exit test` will run the `test` script in all packages.

Package `a` will run first and will be forwarded directly to stdout.
Package `b` will run in parallell, but it's output will be buffered, waiting for `a` to finish.

If `b` fails, the current behavior is to kill all child processes. The output from `b` is lost, and its difficult to know what actually failed.

### Alternatives

There are two ways to solve this.

1. When `b` fails, stop all child processes, and output the buffered logs from `b`. This means that some of the output from `a` is lost.
2. When `b` fails, stop all child processes except `a`. Wait for `a` to finish, and then output the logs from `b` after the complete output from `a`.

I chose the second approach, since that resembles the output from serial execution of the jobs.

### Implementation

1. When a child process fail, stop all other child processes, except the active one.
2. Flush logs from child processes before exiting. If not, output is lost, since it is done asynchronously on a promise, and the main process will exit before all output is written.
3. Refactor how the main process is terminated. Instead of terminating as soon as any child process fails, wait for all child processes to complete. This also requires checking if any dependency failed before starting a child process. Before this was implicitly done by exiting the process on first failure.