### PR TITLE
feat: Add `revDeps` feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,12 @@ let yargsParser = yargs
       nargs: 1,
       describe:
         'Runs commands in packages that have changed since the provided source control branch.'
+    },
+    revDeps: {
+      type: 'string',
+      nargs: 1,
+      describe:
+        'Include all dependents of the filtered packages. Runs after resolving the other package options.'
     }
   })
   .group(
@@ -219,6 +225,7 @@ let runner = new RunGraph(
     recursive: argv.recursive,
     doneCriteria: argv.doneCriteria,
     changedSince: argv.changedSince,
+    revDeps: argv.revDeps,
     exclude,
     excludeMissing: argv.excludeMissing,
     showReport: argv.report,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,8 @@ let yargsParser = yargs
         'Runs commands in packages that have changed since the provided source control branch.'
     },
     revDeps: {
-      type: 'string',
-      nargs: 1,
+      default: false,
+      boolean: true,
       describe:
         'Include all dependents of the filtered packages. Runs after resolving the other package options.'
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ let yargsParser = yargs
       describe:
         'Runs commands in packages that have changed since the provided source control branch.'
     },
-    revDeps: {
+    revRecursive: {
       default: false,
       boolean: true,
       describe:
@@ -225,7 +225,7 @@ let runner = new RunGraph(
     recursive: argv.recursive,
     doneCriteria: argv.doneCriteria,
     changedSince: argv.changedSince,
-    revDeps: argv.revDeps,
+    revRecursive: argv.revRecursive,
     exclude,
     excludeMissing: argv.excludeMissing,
     showReport: argv.report,

--- a/src/rev-deps.spec.ts
+++ b/src/rev-deps.spec.ts
@@ -1,0 +1,40 @@
+import { expandRevDeps } from './rev-deps'
+
+describe('expandRevDeps', () => {
+  it('should return empty array when no packages are supplied', async () => {
+    const res = expandRevDeps([], [{ name: 'a' }, { name: 'b' }])
+
+    expect(res).toEqual([])
+  })
+
+  it('should return the same packages if no matches are found', async () => {
+    const res = expandRevDeps(['c'], [{ name: 'a' }, { name: 'b' }])
+
+    expect(res).toEqual(['c'])
+  })
+
+  it('should return the original list plus the proper reverse dependencies', async () => {
+    const res = expandRevDeps(
+      ['c'],
+      [
+        {
+          name: 'a',
+          dependencies: {
+            c: '*'
+          }
+        },
+        {
+          name: 'b',
+          devDependencies: {
+            c: '*'
+          }
+        },
+        {
+          name: 'd'
+        }
+      ]
+    )
+
+    expect(res).toEqual(['c', 'a', 'b'])
+  })
+})

--- a/src/rev-deps.ts
+++ b/src/rev-deps.ts
@@ -1,0 +1,28 @@
+import { PkgJson } from './workspace'
+
+/**
+ * For given list of packages, expand that list with all dependents on them
+ * @param pkgs original list of packages
+ * @param pkgJsons list of packages in the workspace
+ */
+export const expandRevDeps = (pkgs: string[], pkgJsons: PkgJson[]) => {
+  let index: number = 0
+  while (index < pkgs.length) {
+    const pkg = pkgs[index]
+
+    // find the packages which have the iteratee as dependency or devDependency
+    const found = pkgJsons
+      .filter(
+        p =>
+          (p.dependencies && p.dependencies[pkg]) || (p.devDependencies && p.devDependencies[pkg])
+      )
+      .map(p => p.name)
+      .filter(p => pkgs.indexOf(p) === -1)
+
+    pkgs = pkgs.concat(found)
+
+    index++
+  }
+
+  return pkgs
+}

--- a/src/rev-deps.ts
+++ b/src/rev-deps.ts
@@ -2,7 +2,7 @@ import { PkgJson } from './workspace'
 
 /**
  * For given list of packages, expand that list with all dependents on them
- * @param pkgs original list of packages
+ * @param pkgs original list of packages (to be filtered)
  * @param pkgJsons list of packages in the workspace
  */
 export const expandRevDeps = (pkgs: string[], pkgJsons: PkgJson[]) => {

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -40,7 +40,7 @@ export interface GraphOptions {
   recursive: boolean
   doneCriteria: string | undefined
   changedSince: string | undefined
-  revDeps: boolean
+  revRecursive: boolean
   workspacePath: string
   exclude: string[]
   excludeMissing: boolean
@@ -344,7 +344,7 @@ export class RunGraph {
   }
 
   addRevDeps = (pkgs: string[]) => {
-    if (this.opts.revDeps) {
+    if (this.opts.revRecursive) {
       return expandRevDeps(pkgs, this.pkgJsons)
     } else {
       return pkgs


### PR DESCRIPTION
This PR adds an option to run the specified command on the resolved packages (whether resolved by `changedSince`, glob or naming specific packages) and **their dependents**. 

For example, if you have 3 packages `A`, `B` and `C`, with dependency chain `pA` -> `pB` -> `pC`, if you use `wsrun -revDeps -c test pC` the `test` command will be run on `pA` and `pB` also because they're dependent on the `pC` package.

Tests are missing, will add them when we agree on implementation.