### PR TITLE
improvement: allow overriding FORCE_COLOR 

### DIFF
--- a/src/cmd-process.ts
+++ b/src/cmd-process.ts
@@ -142,7 +142,10 @@ export class CmdProcess {
       cwd:
         this.opts.path ||
         ((process.versions.node < '8.0.0' ? process.cwd : process.cwd()) as string),
-      env: Object.assign(process.env, process.stdout.isTTY ? { FORCE_COLOR: '1' } : {}),
+      env: Object.assign(
+        process.env,
+        process.stdout.isTTY ? { FORCE_COLOR: process.env.FORCE_COLOR || '1' } : {}
+      ),
       stdio:
         this.opts.collectLogs || this.opts.prefixer != null || this.opts.doneCriteria
           ? 'pipe'


### PR DESCRIPTION
Hello, 
I have a problem with a package called `@applitools/eyes-storybook` under `wsrun`. 
Basically, it spawns a process here: https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-storybook/src/storybookConnector.js#L113
The running process is a dev-server of Storybook, which can be found here emitting colored output:
https://github.com/storybookjs/storybook/blob/next/lib/core/src/server/build-dev.js#L218
This colored output gets incorrectly delivered (with encoded colors) to this line: 
https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-storybook/src/storybookConnector.js#L74
which fails to match it via regex, which expects no colored output. 
I don't think it's a good idea to make this regex harder to read and it's just better to allow setting `FORCE_COLOR=0`.
Currently I can't run my pre-push hook via `wsrun` because of the issue. 

I think this might affect other flows where first spawn is done via wsrun, next by executed command in package inside of a repo, and another one by that command if it does colored output and second command in the chain tries to match against it.

Please let me know what you think on this.
Thanks!