### PR TITLE
fix: Collected logs shouldn't have multiple package name headings

### DIFF
--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -59,7 +59,6 @@ export class RunGraph {
   private resultMap = new Map<string, Result>()
   private throat: PromiseFnRunner = passThrough
   private consoles: ConsoleFactory
-  private prefixer = new Prefixer().prefixer
   pathRewriter = (pkgPath: string, line: string) => fixPaths(this.opts.workspacePath, pkgPath, line)
 
   constructor(
@@ -79,6 +78,18 @@ export class RunGraph {
 
     if (opts.collectLogs) this.consoles = new SerializedConsole(console)
     else this.consoles = new DefaultConsole()
+  }
+
+  private globalPrefixer = new Prefixer().prefixer
+  get prefixer() {
+    if (this.opts.addPrefix) {
+      if (this.opts.collectLogs) {
+        return new Prefixer().prefixer
+      } else {
+        return this.globalPrefixer
+      }
+    }
+    return undefined
   }
 
   closeAll() {
@@ -142,7 +153,7 @@ export class RunGraph {
       rejectOnNonZeroExit: false,
       silent: true,
       collectLogs: this.opts.collectLogs,
-      prefixer: this.opts.addPrefix ? this.prefixer : undefined,
+      prefixer: this.prefixer,
       doneCriteria: this.opts.doneCriteria,
       path: this.pkgPaths[pkg]
     })
@@ -194,7 +205,7 @@ export class RunGraph {
         const child = new CmdProcess(c, cmdLine, pkg, {
           rejectOnNonZeroExit: this.opts.fastExit,
           collectLogs: this.opts.collectLogs,
-          prefixer: this.opts.addPrefix ? this.prefixer : undefined,
+          prefixer: this.prefixer,
           pathRewriter: this.opts.rewritePaths ? this.pathRewriter : undefined,
           doneCriteria: this.opts.doneCriteria,
           path: this.pkgPaths[pkg]

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -156,7 +156,7 @@ export class RunGraph {
       rejectOnNonZeroExit: false,
       silent: true,
       collectLogs: this.opts.collectLogs,
-      prefixer: this.prefixer,
+      prefixer: this.createOrProvidePrefixerForProcess,
       doneCriteria: this.opts.doneCriteria,
       path: this.pkgPaths[pkg]
     })
@@ -208,7 +208,7 @@ export class RunGraph {
         const child = new CmdProcess(c, cmdLine, pkg, {
           rejectOnNonZeroExit: this.opts.fastExit,
           collectLogs: this.opts.collectLogs,
-          prefixer: this.prefixer,
+          prefixer: this.createOrProvidePrefixerForProcess,
           pathRewriter: this.opts.rewritePaths ? this.pathRewriter : undefined,
           doneCriteria: this.opts.doneCriteria,
           path: this.pkgPaths[pkg]

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -81,7 +81,10 @@ export class RunGraph {
   }
 
   private globalPrefixer = new Prefixer().prefixer
-  get prefixer() {
+  /**
+   * Creates or provides the global prefixer. This depends on the collect-logs flag which describes whether the processes should use a shared prefixer.
+   */
+  get createOrProvidePrefixerForProcess() {
     if (this.opts.addPrefix) {
       if (this.opts.collectLogs) {
         return new Prefixer().prefixer

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -84,7 +84,7 @@ export class RunGraph {
   /**
    * Creates or provides the global prefixer. This depends on the collect-logs flag which describes whether the processes should use a shared prefixer.
    */
-  get createOrProvidePrefixerForProcess() {
+  private createOrProvidePrefixerForProcess = () => {
     if (this.opts.addPrefix) {
       if (this.opts.collectLogs) {
         return new Prefixer().prefixer
@@ -156,7 +156,7 @@ export class RunGraph {
       rejectOnNonZeroExit: false,
       silent: true,
       collectLogs: this.opts.collectLogs,
-      prefixer: this.createOrProvidePrefixerForProcess,
+      prefixer: this.createOrProvidePrefixerForProcess(),
       doneCriteria: this.opts.doneCriteria,
       path: this.pkgPaths[pkg]
     })
@@ -208,7 +208,7 @@ export class RunGraph {
         const child = new CmdProcess(c, cmdLine, pkg, {
           rejectOnNonZeroExit: this.opts.fastExit,
           collectLogs: this.opts.collectLogs,
-          prefixer: this.createOrProvidePrefixerForProcess,
+          prefixer: this.createOrProvidePrefixerForProcess(),
           pathRewriter: this.opts.rewritePaths ? this.pathRewriter : undefined,
           doneCriteria: this.opts.doneCriteria,
           path: this.pkgPaths[pkg]


### PR DESCRIPTION
When running `wsrun` with `--collect-logs` option, all processes use the same Prefixer instance which has internal state (the last package that used the prefixer). This caused really weird logs, which are grouped but have unnecessary package headings:
```
$ wsrun--series --bin runner -p 'package-*' --collect-logs -c test:backend
package-1
 | $ sleep 3 && jest --runInBand --forceExit
package-1
 | dropdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | createdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | `runner test:backend` failed with exit code 1
package-2
 | $ jest --runInBand --forceExit
package-2
 | dropdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | createdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | `runner test:backend` failed with exit code 1
package-3
 | $ jest --runInBand --forceExit
package-3
 | dropdb not found. Please install the postgres CLI tools on your local machine to create a test db
package-3
 | createdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | `runner test:backend` failed with exit code 1
```

This PR fixes this issue by instantiating separate Prefixers for each process if the `--collect-logs` option is used so that the logs looks like this:
```
$ wsrun--series --bin runner -p 'package-*' --collect-logs -c test:backend
package-1
 | $ sleep 3 && jest --runInBand --forceExit
 | dropdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | createdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | `runner test:backend` failed with exit code 1
package-2
 | $ jest --runInBand --forceExit
 | dropdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | createdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | `runner test:backend` failed with exit code 1
package-3
 | $ jest --runInBand --forceExit
 | dropdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | createdb not found. Please install the postgres CLI tools on your local machine to create a test db
 | `runner test:backend` failed with exit code 1
```

This is really a bug fix TBH.