### PR TITLE
improvement: --no-private flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,12 +47,18 @@ let yargsParser = yargs
       describe: 'Same as "stages" but with no parallelism at the stage level'
     }
   })
-  .group(['recursive', 'package', 'changedSince'], 'Package Options:')
+  .group(['recursive', 'package', 'changedSince', 'no-private'], 'Package Options:')
   .options({
     package: {
       alias: 'p',
       describe: 'Run only for packages matching this glob. Can be used multiple times.',
       type: 'array'
+    },
+    'no-private': {
+      alias: 'n',
+      describe: 'Run only for non-private packages.',
+      default: false,
+      boolean: true
     },
     c: {
       boolean: true,
@@ -63,7 +69,7 @@ let yargsParser = yargs
       alias: 'r',
       default: false,
       boolean: true,
-      describe: 'Execute the same script on all of its dependencies, too'
+      describe: 'Execute the same script on all of its dependencies, too.'
     },
     changedSince: {
       type: 'string',
@@ -211,7 +217,10 @@ const pkgPaths = _.mapValues(
   v => v.path
 )
 
-const pkgJsons = _.map(pkgs, pkg => pkg.json)
+let pkgJsons = _.map(pkgs, pkg => pkg.json)
+if (argv.noPrivate) {
+  pkgJsons = pkgJsons.filter(pkg => pkg.private !== true)
+}
 
 let runner = new RunGraph(
   pkgJsons,

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -14,6 +14,7 @@ export interface PkgJson {
   dependencies?: Dict<string>
   devDependencies?: Dict<string>
   scripts?: { [name: string]: string }
+  private?: boolean
 }
 
 export type Packages = Dict<{

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -168,6 +168,23 @@ describe('basic', () => {
     )
   })
 
+  it('should support no-private', async () => {
+    await withScaffold(
+      {
+        packages: [
+          echo.makePkg({ name: 'public', dependencies: {} }),
+          echo.makePkg({ name: 'private', dependencies: {}, private: true })
+        ]
+      },
+      async () => {
+        let tst = await wsrun('--serial --no-private doecho')
+        expect(tst.status).toBeFalsy()
+        let output = String(await echo.getOutput())
+        expect(output).toEqual('public\n')
+      }
+    )
+  })
+
   it('should not break with namespaced pkgs', async () => {
     await withScaffold(
       {

--- a/tests/test.util.ts
+++ b/tests/test.util.ts
@@ -27,6 +27,7 @@ export type PackageJson = {
   dependencies?: { [name: string]: string }
   devDependencies?: { [name: string]: string }
   scripts?: { [name: string]: string }
+  private?: boolean
 }
 
 let counter = process.env['JEST_WORKER_ID'] || '0'


### PR DESCRIPTION
I ended up writing a script that could be entirely replaced by `wsrun` save for one feature - skipping private packages. This PR introduces a flag to handle this use case.